### PR TITLE
Avoid division by zero bug

### DIFF
--- a/lib/forceCluster.js
+++ b/lib/forceCluster.js
@@ -28,7 +28,9 @@ function cluster (centers) {
       r = d.radius + (c.radius || 0);
 
       if (l != r) {
-        l = (l - r) / l * alpha;
+        if (l !== 0) {
+          l = (l - r) / l * alpha;
+        }
         d.x -= x *= l;
         d.y -= y *= l;
         c.x += (1 - centerInertia) * x;


### PR DESCRIPTION
In the unfortunate case where a node has `x` and `y` coordinates exactly equal to the cluster center point, this line causes a division by zero, setting all of `d.x`, `d.y`, `c.x`, and `c.y` properties to NaN, which stay like that forever, so it's better avoided :)
