### PR TITLE
Make tap-min a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,7 @@
   "pre-push": [
     "dist"
   ],
-  "dependencies": {
-    "tap-min": "^1.1.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "babel-eslint": "^7.0.0",
     "babel-plugin-external-helpers": "^6.8.0",
@@ -51,6 +49,7 @@
     "rollup-plugin-babel": "^2.6.1",
     "rollup-watch": "^2.5.0",
     "sinon": "^1.17.6",
+    "tap-min": "^1.1.0",
     "tape": "^4.6.2",
     "uglify-js": "^2.7.3"
   }


### PR DESCRIPTION
This makes `tap-min` a dev dependency, as it seems to be only needed to run the unit tests.  It should probably not be a production requirement.  Right now, installing `d3-force-cluster` from NPM pulls in a lot of secondary dependencies that seem unnecessary…

…unless I'm overlooking something.